### PR TITLE
Fix tsconfig inheritance for apps and libs

### DIFF
--- a/apps/auth/tsconfig.app.json
+++ b/apps/auth/tsconfig.app.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.backend.base.json",
   "compilerOptions": {
     "outDir": "dist",
     "module": "nodenext",

--- a/apps/auth/tsconfig.spec.json
+++ b/apps/auth/tsconfig.spec.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/jest",
     "types": ["jest", "node"],

--- a/apps/order/tsconfig.app.json
+++ b/apps/order/tsconfig.app.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.backend.base.json",
   "compilerOptions": {
     "outDir": "dist",
     "module": "nodenext",

--- a/apps/order/tsconfig.json
+++ b/apps/order/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.backend.base.json",
   "files": [],
   "include": [],
   "references": [

--- a/apps/product/tsconfig.app.json
+++ b/apps/product/tsconfig.app.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.backend.base.json",
   "compilerOptions": {
     "outDir": "dist",
     "module": "nodenext",

--- a/apps/product/tsconfig.json
+++ b/apps/product/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.backend.base.json",
   "files": [],
   "include": [],
   "references": [

--- a/apps/product/tsconfig.spec.json
+++ b/apps/product/tsconfig.spec.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/jest",
     "types": ["jest", "node"],

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -21,7 +21,7 @@
       "path": "./tsconfig.spec.json"
     }
   ],
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.frontend.base.json",
   "compilerOptions": {
     "jsx": "react-jsx",
     "moduleResolution": "bundler",

--- a/apps/web/tsconfig.spec.json
+++ b/apps/web/tsconfig.spec.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/vitest",
     "moduleResolution": "NodeNext",

--- a/libs/backend/core/tsconfig.json
+++ b/libs/backend/core/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.backend.base.json",
   "files": [],
   "include": [],
   "references": [

--- a/libs/backend/core/tsconfig.lib.json
+++ b/libs/backend/core/tsconfig.lib.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.backend.base.json",
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",

--- a/libs/backend/core/tsconfig.spec.json
+++ b/libs/backend/core/tsconfig.spec.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/jest",
     "types": ["jest", "node"],

--- a/libs/backend/db/tsconfig.json
+++ b/libs/backend/db/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.backend.base.json",
   "files": [],
   "include": [],
   "references": [

--- a/libs/backend/db/tsconfig.lib.json
+++ b/libs/backend/db/tsconfig.lib.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.backend.base.json",
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",

--- a/libs/backend/db/tsconfig.spec.json
+++ b/libs/backend/db/tsconfig.spec.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/jest",
     "types": ["jest", "node"],

--- a/libs/backend/email/tsconfig.json
+++ b/libs/backend/email/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.backend.base.json",
   "files": [],
   "include": [],
   "references": [

--- a/libs/backend/email/tsconfig.lib.json
+++ b/libs/backend/email/tsconfig.lib.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.backend.base.json",
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",

--- a/libs/backend/email/tsconfig.spec.json
+++ b/libs/backend/email/tsconfig.spec.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/jest",
     "types": ["jest", "node"],

--- a/libs/backend/payment/tsconfig.json
+++ b/libs/backend/payment/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.backend.base.json",
   "files": [],
   "include": [],
   "references": [

--- a/libs/backend/payment/tsconfig.lib.json
+++ b/libs/backend/payment/tsconfig.lib.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.backend.base.json",
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",

--- a/libs/backend/payment/tsconfig.spec.json
+++ b/libs/backend/payment/tsconfig.spec.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/jest",
     "types": ["jest", "node"],

--- a/libs/backend/workflows/tsconfig.json
+++ b/libs/backend/workflows/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.backend.base.json",
   "files": [],
   "include": [],
   "references": [

--- a/libs/backend/workflows/tsconfig.lib.json
+++ b/libs/backend/workflows/tsconfig.lib.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.backend.base.json",
   "compilerOptions": {
     "baseUrl": ".",
     "rootDir": "src",

--- a/libs/backend/workflows/tsconfig.spec.json
+++ b/libs/backend/workflows/tsconfig.spec.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/jest",
     "types": ["jest", "node"],


### PR DESCRIPTION
## Summary
- use `tsconfig.backend.base.json` for backend projects
- use `tsconfig.frontend.base.json` for the web app
- make spec configs extend their local tsconfig

## Testing
- `npx nx test` *(fails: Could not find Nx modules)*

------
https://chatgpt.com/codex/tasks/task_e_68523563acc48321a11efe850d1b8a7e