### PR TITLE
Fix tsconfig outputs

### DIFF
--- a/apps/auth/tsconfig.app.json
+++ b/apps/auth/tsconfig.app.json
@@ -1,15 +1,7 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.backend.base.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "module": "nodenext",
-    "types": ["node"],
-    "rootDir": "src",
-    "moduleResolution": "nodenext",
-    "tsBuildInfoFile": "dist/tsconfig.app.tsbuildinfo",
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
-    "target": "es2021"
+    "outDir": "../../dist/out-tsc"
   },
   "include": ["src/**/*.ts"],
   "exclude": [

--- a/apps/auth/tsconfig.spec.json
+++ b/apps/auth/tsconfig.spec.json
@@ -1,10 +1,8 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/jest",
     "types": ["jest", "node"],
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },

--- a/apps/order/tsconfig.app.json
+++ b/apps/order/tsconfig.app.json
@@ -1,15 +1,7 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.backend.base.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "module": "nodenext",
-    "types": ["node"],
-    "rootDir": "src",
-    "moduleResolution": "nodenext",
-    "tsBuildInfoFile": "dist/tsconfig.app.tsbuildinfo",
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
-    "target": "es2021"
+    "outDir": "../../dist/out-tsc"
   },
   "include": ["src/**/*.ts"],
   "exclude": [

--- a/apps/order/tsconfig.json
+++ b/apps/order/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.backend.base.json",
   "files": [],
   "include": [],
   "references": [

--- a/apps/order/tsconfig.spec.json
+++ b/apps/order/tsconfig.spec.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "module": "commonjs",
     "types": ["jest", "node"]
   },
   "include": [

--- a/apps/product/tsconfig.app.json
+++ b/apps/product/tsconfig.app.json
@@ -1,15 +1,7 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.backend.base.json",
   "compilerOptions": {
-    "outDir": "dist",
-    "module": "nodenext",
-    "types": ["node"],
-    "rootDir": "src",
-    "moduleResolution": "nodenext",
-    "tsBuildInfoFile": "dist/tsconfig.app.tsbuildinfo",
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
-    "target": "es2021"
+    "outDir": "../../dist/out-tsc"
   },
   "include": ["src/**/*.ts"],
   "exclude": [

--- a/apps/product/tsconfig.json
+++ b/apps/product/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.backend.base.json",
   "files": [],
   "include": [],
   "references": [

--- a/apps/product/tsconfig.spec.json
+++ b/apps/product/tsconfig.spec.json
@@ -1,10 +1,8 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/jest",
     "types": ["jest", "node"],
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },

--- a/apps/web/app/services/logger.server.ts
+++ b/apps/web/app/services/logger.server.ts
@@ -1,4 +1,4 @@
-import { createLoggerOptions } from '@projectx/core/lib/logger/logger';
+import { createLoggerOptions } from '@projectx/core/lib/logger';
 import pino from 'pino';
 
 import { environment } from '~/config/app.config.server';

--- a/apps/web/tsconfig.app.json
+++ b/apps/web/tsconfig.app.json
@@ -13,17 +13,7 @@
     "rootDirs": [".", "./.react-router/types"],
     "tsBuildInfoFile": "./dist/tsconfig.app.tsbuildinfo",
     "paths": {
-      "~/*": ["./app/*"],
-      "@projectx/models": ["../../libs/models/src/index.ts"],
-      "@projectx/models/*": ["../../libs/models/src/*"],
-      "@projectx/email": ["../../libs/backend/email/src/index.ts"],
-      "@projectx/email/*": ["../../libs/backend/email/src/*"],
-      "@projectx/ui": ["../../libs/frontend/ui/src/index.ts"],
-      "@projectx/ui/*": ["../../libs/frontend/ui/src/*"],
-      "@projectx/core": ["../../libs/backend/core/src/index.ts"],
-      "@projectx/core/*": ["../../libs/backend/core/src/*"],
-      "@projectx/db": ["../../libs/backend/db/src/index.ts"],
-      "@projectx/db/*": ["../../libs/backend/db/src/*"]
+      "~/*": ["./app/*"]
     },
     "allowSyntheticDefaultImports": true,
     "module": "ESNext",

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -21,7 +21,7 @@
       "path": "./tsconfig.spec.json"
     }
   ],
-  "extends": "../../tsconfig.base.json",
+  "extends": "../../tsconfig.frontend.base.json",
   "compilerOptions": {
     "jsx": "react-jsx",
     "moduleResolution": "bundler",

--- a/apps/web/tsconfig.spec.json
+++ b/apps/web/tsconfig.spec.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.base.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/vitest",
     "moduleResolution": "NodeNext",

--- a/libs/backend/core/tsconfig.json
+++ b/libs/backend/core/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.backend.base.json",
   "files": [],
   "include": [],
   "references": [

--- a/libs/backend/core/tsconfig.lib.json
+++ b/libs/backend/core/tsconfig.lib.json
@@ -1,13 +1,9 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.backend.base.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "rootDir": "src",
-    "outDir": "dist",
-    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "outDir": "../../../dist/out-tsc",
     "emitDeclarationOnly": false,
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
     "forceConsistentCasingInFileNames": true,
     "types": ["node"],
     "target": "es2021",
@@ -17,11 +13,7 @@
     "noFallthroughCasesInSwitch": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "skipLibCheck": true,
-    "paths": {
-      "@projectx/models": ["../../../libs/models/src/index.ts"],
-      "@projectx/db": ["../../../libs/backend/db/src/index.ts"]
-    }
+    "skipLibCheck": true
   },
   "include": ["src/**/*.ts"],
   "references": [

--- a/libs/backend/core/tsconfig.spec.json
+++ b/libs/backend/core/tsconfig.spec.json
@@ -1,10 +1,8 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/jest",
     "types": ["jest", "node"],
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
     "forceConsistentCasingInFileNames": true
   },
   "include": [

--- a/libs/backend/db/tsconfig.json
+++ b/libs/backend/db/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.backend.base.json",
   "files": [],
   "include": [],
   "references": [

--- a/libs/backend/db/tsconfig.lib.json
+++ b/libs/backend/db/tsconfig.lib.json
@@ -1,13 +1,9 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.backend.base.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "rootDir": "src",
-    "outDir": "dist",
-    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "outDir": "../../../dist/out-tsc",
     "emitDeclarationOnly": false,
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
     "forceConsistentCasingInFileNames": true,
     "types": ["node"],
     "target": "es2021",
@@ -17,10 +13,7 @@
     "noFallthroughCasesInSwitch": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "skipLibCheck": true,
-    "paths": {
-      "@projectx/models": ["../../../libs/models/src/index.ts"]
-    }
+    "skipLibCheck": true
   },
   "include": ["src/**/*.ts"],
   "references": [

--- a/libs/backend/db/tsconfig.spec.json
+++ b/libs/backend/db/tsconfig.spec.json
@@ -1,10 +1,8 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/jest",
     "types": ["jest", "node"],
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
     "forceConsistentCasingInFileNames": true
   },
   "include": [

--- a/libs/backend/email/tsconfig.json
+++ b/libs/backend/email/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.backend.base.json",
   "files": [],
   "include": [],
   "references": [

--- a/libs/backend/email/tsconfig.lib.json
+++ b/libs/backend/email/tsconfig.lib.json
@@ -1,13 +1,9 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.backend.base.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "rootDir": "src",
-    "outDir": "dist",
-    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "outDir": "../../../dist/out-tsc",
     "emitDeclarationOnly": false,
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
     "forceConsistentCasingInFileNames": true,
     "types": ["node"],
     "target": "es2021",

--- a/libs/backend/email/tsconfig.spec.json
+++ b/libs/backend/email/tsconfig.spec.json
@@ -1,10 +1,8 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/jest",
     "types": ["jest", "node"],
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
     "forceConsistentCasingInFileNames": true
   },
   "include": [

--- a/libs/backend/payment/tsconfig.json
+++ b/libs/backend/payment/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.backend.base.json",
   "files": [],
   "include": [],
   "references": [

--- a/libs/backend/payment/tsconfig.lib.json
+++ b/libs/backend/payment/tsconfig.lib.json
@@ -1,13 +1,9 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.backend.base.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "rootDir": "src",
-    "outDir": "dist",
-    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "outDir": "../../../dist/out-tsc",
     "emitDeclarationOnly": false,
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
     "forceConsistentCasingInFileNames": true,
     "types": ["node"],
     "target": "es2021",

--- a/libs/backend/payment/tsconfig.spec.json
+++ b/libs/backend/payment/tsconfig.spec.json
@@ -1,10 +1,8 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/jest",
     "types": ["jest", "node"],
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
     "forceConsistentCasingInFileNames": true
   },
   "include": [

--- a/libs/backend/workflows/tsconfig.json
+++ b/libs/backend/workflows/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.backend.base.json",
   "files": [],
   "include": [],
   "references": [

--- a/libs/backend/workflows/tsconfig.lib.json
+++ b/libs/backend/workflows/tsconfig.lib.json
@@ -1,13 +1,9 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "../../../tsconfig.backend.base.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "rootDir": "src",
-    "outDir": "dist",
-    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "outDir": "../../../dist/out-tsc",
     "emitDeclarationOnly": false,
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
     "forceConsistentCasingInFileNames": true,
     "types": ["node"],
     "target": "es2021",
@@ -17,10 +13,7 @@
     "noFallthroughCasesInSwitch": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "skipLibCheck": true,
-    "paths": {
-      "@projectx/core": ["../../../libs/backend/core/src/index.ts"]
-    }
+    "skipLibCheck": true
   },
   "include": ["src/**/*.ts"],
   "references": [

--- a/libs/backend/workflows/tsconfig.spec.json
+++ b/libs/backend/workflows/tsconfig.spec.json
@@ -1,10 +1,8 @@
 {
-  "extends": "../../../tsconfig.base.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/jest",
     "types": ["jest", "node"],
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
     "forceConsistentCasingInFileNames": true
   },
   "include": [

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -18,12 +18,19 @@
     "baseUrl": ".",
     "paths": {
       "@projectx/core": ["libs/backend/core/src/index.ts"],
+      "@projectx/core/*": ["libs/backend/core/src/*"],
       "@projectx/db": ["libs/backend/db/src/index.ts"],
+      "@projectx/db/*": ["libs/backend/db/src/*"],
       "@projectx/email": ["libs/backend/email/src/index.ts"],
+      "@projectx/email/*": ["libs/backend/email/src/*"],
       "@projectx/models": ["libs/models/src/index.ts"],
+      "@projectx/models/*": ["libs/models/src/*"],
       "@projectx/payment": ["libs/backend/payment/src/index.ts"],
+      "@projectx/payment/*": ["libs/backend/payment/src/*"],
       "@projectx/ui": ["libs/frontend/ui/src/index.ts"],
-      "@projectx/workflows": ["libs/backend/workflows/src/index.ts"]
+      "@projectx/ui/*": ["libs/frontend/ui/src/*"],
+      "@projectx/workflows": ["libs/backend/workflows/src/index.ts"],
+      "@projectx/workflows/*": ["libs/backend/workflows/src/*"]
     },
     "sourceMap": true,
     "skipDefaultLibCheck": true,


### PR DESCRIPTION
## Summary
- change backend builds to output under `dist/out-tsc` and keep improved base config inheritance

## Testing
- `npx nx test` *(fails: prompts to install nx)*

------
https://chatgpt.com/codex/tasks/task_e_68523563acc48321a11efe850d1b8a7e